### PR TITLE
Correcting typo

### DIFF
--- a/dataset_schema.json
+++ b/dataset_schema.json
@@ -204,5 +204,5 @@
         }
     },
     "additionalProperties": false,
-    "required" : [ "title", "types", "creators", "licenses", "description", "keywords", "version", "distribution" ]
+    "required" : [ "title", "types", "creators", "licenses", "description", "keywords", "version", "distributions" ]
 }


### PR DESCRIPTION
Correcting typo in field name in https://github.com/CONP-PCNO/schema/pull/2 that causes tests to fail.